### PR TITLE
Use basename instead of hardcoded names

### DIFF
--- a/src/dbwebb.bash
+++ b/src/dbwebb.bash
@@ -6,7 +6,7 @@
 ##
 # Globals (prefer none)
 # 
-readonly APP_NAME="dbwebb3"
+readonly APP_NAME="$(basename "$0")"
 readonly DBW_CONFIG_DIR=${DBWEBB_CONFIG_DIR:-"$HOME/.dbwebb"}
 
 

--- a/src/dbwebb.bash
+++ b/src/dbwebb.bash
@@ -225,7 +225,7 @@ check_environment()
 
     printf "dbwebb utilities."
     printf "\\n------------------------------------\\n"
-    check_command_version "dbwebb3" ""  "| cut -d ' ' -f 1"
+    check_command_version "$APP_NAME" ""  "| cut -d ' ' -f 1"
     printf "\\n"
     
     printf "dbwebb environment."


### PR DESCRIPTION
Sometimes people run scripts etc. that are not on the PATH. So using basename will help everyone find the correct script, instead of hard coding it to a specific name. Also lets one change the name whenever one feels like it.