### PR TITLE
Use localy installed ShellCheck if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,12 @@ CHECK_VERSION = $(ECHO) `basename $(1)` `$(1) --version $(2)` `which $(1)`
 #
 BIN     := .bin
 
-SHELLCHECK := $(BIN)/shellcheck
+ifeq ($(wildcard $(BIN)/shellcheck),)
+	SHELLCHECK := shellcheck
+else
+	SHELLCHECK := $(BIN)/shellcheck
+endif
+
 BATS       := $(BIN)/bats
 
 INSTALL_DIR := /usr/local/bin


### PR DESCRIPTION
Let's not force users to download stuff to a hidden folder,
in case they actually have the binary already installed